### PR TITLE
Smarter enabling

### DIFF
--- a/resources/js/components/fieldtypes/CopyReviewUrlButton.vue
+++ b/resources/js/components/fieldtypes/CopyReviewUrlButton.vue
@@ -14,15 +14,30 @@
 <script>
     export default {
         mixins: [Fieldtype],
-        inject: ["storeName"],
 
         computed: {
-            published() {
-                return this.$store.state.publish[this.storeName].values.published;
+            publishForm() {
+                let vm = this;
+                while (true) {
+                    let parent = vm.$parent;
+
+                    if (!parent) {
+                        return false;
+                    }
+
+                    if (parent.$options._componentTag == "entry-publish-form") {
+                        return parent;
+                    }
+                    vm = parent;
+                }
             },
 
             show() {
-                return this.meta.has_revision || !this.published;
+                return (
+                    this.publishForm &&
+                    !this.publishForm.isDirty &&
+                    (this.publishForm.isWorkingCopy || !this.published)
+                );
             },
         },
         methods: {

--- a/src/Fieldtypes/Review.php
+++ b/src/Fieldtypes/Review.php
@@ -29,10 +29,7 @@ class Review extends Fieldtype
             return [];
         }
 
-        return [
-            'site_url' => $this->makeUrl($entry),
-            'has_revision' => $entry->hasWorkingCopy(),
-        ];
+        return ['site_url' => $this->makeUrl($entry)];
     }
 
     private function makeUrl(Entry $entry): string


### PR DESCRIPTION
References https://github.com/transformstudios/zakat-v3/issues/460

Use the live updated data from the publish form to enable/disable the button.

Note it's always disabled when there are unsaved changes.