### PR TITLE
Persist the token

### DIFF
--- a/src/Support/URL.php
+++ b/src/Support/URL.php
@@ -3,7 +3,7 @@
 namespace TransformStudios\Review\Support;
 
 use Statamic\Entries\Entry;
-use Statamic\Facades\Token as TockenFacade;
+use Statamic\Facades\Token as TokenFacade;
 use Statamic\Tokens\Token;
 use TransformStudios\Review\TokenHandler;
 
@@ -12,16 +12,12 @@ class URL
     public static function reviewUrl(Entry $entry): string
     {
         /** @var \Statamic\Tokens\Token */
-        $token = tap(
-            TockenFacade::make(
-                token: null,
-                handler: TokenHandler::class,
-                data: ['id' => $entry->id()]
-            ),
-            fn (Token $token) => $token
-                ->expireAt(now()->addMonths(6))
-                ->save()
-        );
+        if (! $token = TokenFacade::find($entry->id())) {
+            $token = tap(
+                TokenFacade::make($entry->id(), TokenHandler::class),
+                fn (Token $token) => $token->expireAt(now()->addMonths(6))->save()
+            );
+        }
 
         return $entry->absoluteUrl().'?token='.$token->token();
     }

--- a/src/TokenHandler.php
+++ b/src/TokenHandler.php
@@ -12,7 +12,9 @@ class TokenHandler
     public function handle(Token $token, $request, Closure $next)
     {
         /** @var \Statamic\Entries\Entry */
-        $entry = EntryFacade::find($token->get('id'));
+        if (! $entry = EntryFacade::find($token->token())) {
+            return $next($request);
+        }
 
         if ($this->isLive($entry)) {
             return redirect($entry->url());


### PR DESCRIPTION
The token URL could change, which makes it difficult to share, as it might expire then be unreachable.

It's now based on the `id` of the entry, which will never change.

References https://github.com/transformstudios/zakat-v3/issues/992