### PR TITLE
Keep the slug

### DIFF
--- a/src/TokenHandler.php
+++ b/src/TokenHandler.php
@@ -48,9 +48,14 @@ class TokenHandler
             $entry->date(now());
         }
 
+        // if the revision changes the slug, the url is wrong and the review link 404s
+        $originalSlug = $entry->slug();
+
         if ($entry->hasWorkingCopy()) {
             $entry = $entry->fromWorkingCopy();
         }
+
+        $entry->slug($originalSlug);
 
         return $entry->published(true);
     }


### PR DESCRIPTION
References https://github.com/transformstudios/zakat-v3/issues/1011

If a revision changed the slug, the review link would 404. It now doesn't because we swap in the old url so Statamic can find the entry.