### PR TITLE
Parent might be an empty Entry

### DIFF
--- a/src/Fieldtypes/Review.php
+++ b/src/Fieldtypes/Review.php
@@ -22,9 +22,15 @@ class Review extends Fieldtype
             return [];
         }
 
-        // when it's a new entry the "parent" is the collection
+        // when it's a new entry the "parent" might be a collection
         // in this case, we can't show it anyway so return empty
         if ($entry instanceof Collection) {
+            return [];
+        }
+
+        // if there's a computed field in the entry's collection that uses augmentation,
+        // this maybe be an empty entry, without an id
+        if (is_null($entry->id())) {
             return [];
         }
 


### PR DESCRIPTION
If the collection the entry is in has a computed field that uses augmentation, a blank entry is returned instead of a collection.

This PR handles that.